### PR TITLE
Fix table hover handlers

### DIFF
--- a/src/componentes/Table/index.tsx
+++ b/src/componentes/Table/index.tsx
@@ -236,7 +236,7 @@ export function Table({ objectColors, onHoverClasses}: TableProps) {
               className={`${objectColors.B11 || styles.defaultStyle} ${
                 styles.defaultCelula
               }`}
-              onMouseEnter={() => handleMouseEnter(objectColors.B1)}
+              onMouseEnter={() => handleMouseEnter(objectColors.B11)}
               onMouseLeave={handleMouseLeave}
             >
               K4s
@@ -1325,7 +1325,7 @@ export function Table({ objectColors, onHoverClasses}: TableProps) {
               className={`${objectColors.K13 || styles.defaultStyle} ${
                 styles.defaultCelula
               }`}
-              onMouseEnter={() => handleMouseEnter(objectColors.K3)}
+              onMouseEnter={() => handleMouseEnter(objectColors.K13)}
               onMouseLeave={handleMouseLeave}
             >
               42s


### PR DESCRIPTION
## Summary
- fix incorrect onMouseEnter props on B11 and K13 table cells

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847b950bcf88329a18605cc56dd396d