### PR TITLE
fix: hover handler for B11 uses correct color key

### DIFF
--- a/src/componentes/Table/index.tsx
+++ b/src/componentes/Table/index.tsx
@@ -236,7 +236,7 @@ export function Table({ objectColors, onHoverClasses}: TableProps) {
               className={`${objectColors.B11 || styles.defaultStyle} ${
                 styles.defaultCelula
               }`}
-              onMouseEnter={() => handleMouseEnter(objectColors.B1)}
+              onMouseEnter={() => handleMouseEnter(objectColors.B11)}
               onMouseLeave={handleMouseLeave}
             >
               K4s


### PR DESCRIPTION
## Summary
- correct onMouseEnter color handler for B11 row in Table component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find type definition file for 'babel__core')*

------
https://chatgpt.com/codex/tasks/task_e_6847bc0611848329b34c8659084c586a