### PR TITLE
Add Gerenciamento page

### DIFF
--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -5,8 +5,9 @@ import  Login  from "../screens/Login";
 import { Home } from "../screens/Home";
 import { Home_1 } from "../screens/Home_1";
 import { Home_2 } from "../screens/Home_2";
-import { PrivateRoute } from "./privateRoute"
+import { PrivateRoute } from "./privateRoute";
 import { Register } from "../screens/Register";
+import Gerenciamento from "../screens/Gerenciamento";
 
 export const RoutesApp = () => {
 //   const levelAccess = useSelector((state) => state.user.userData?.data?.acesso);
@@ -28,6 +29,7 @@ export const RoutesApp = () => {
             <Route path="/spin&go&reg" element={<Home_2/>} />
           </Route>
           <Route element={<PrivateRoute requiredLevels={["0"]}/>}>
+            <Route path="/gerenciamento" element={<Gerenciamento />} />
             <Route path="/register" element={<Register/>} />
           </Route>
           

--- a/src/componentes/CabecalhoVerde/index.tsx
+++ b/src/componentes/CabecalhoVerde/index.tsx
@@ -73,9 +73,9 @@ export default function CabecalhoVerde({ children }: CardProps) {
         <span
           className={style.sair}
           style={{ cursor: "pointer" }}
-          onClick={() => navigate("/register")}
+          onClick={() => navigate("/gerenciamento")}
         >
-          Criar Usuário
+          Gerenciamento
         </span>
       )}
     </div>

--- a/src/screens/Gerenciamento/index.tsx
+++ b/src/screens/Gerenciamento/index.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from "react";
+import { collection, getDocs, query, where } from "firebase/firestore";
+import CabecalhoVerde from "../../componentes/CabecalhoVerde";
+import { db } from "../../Server/firebase";
+import style from "./style.module.css";
+import { useNavigate } from "react-router-dom";
+
+interface UserInfo {
+  nome: string;
+  email: string;
+  statusUsuario: boolean;
+  nivel: string;
+  statusPagamento: boolean | string;
+}
+
+export default function Gerenciamento() {
+  const [usuarios, setUsuarios] = useState<UserInfo[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      try {
+        const usersSnapshot = await getDocs(collection(db, "usuario"));
+        const list: UserInfo[] = [];
+        for (const docUser of usersSnapshot.docs) {
+          const dataUser = docUser.data();
+          let nivel = "";
+          let statusPagamento: boolean | string = "N/A";
+          const acessoQuery = query(
+            collection(db, "acesso"),
+            where("id", "==", dataUser.id)
+          );
+          const acessoSnapshot = await getDocs(acessoQuery);
+          if (!acessoSnapshot.empty) {
+            const acessoData = acessoSnapshot.docs[0].data();
+            nivel = String(acessoData.nivel);
+            statusPagamento = acessoData.status;
+          }
+          list.push({
+            nome: dataUser.nome,
+            email: dataUser.email,
+            statusUsuario: dataUser.status,
+            nivel,
+            statusPagamento,
+          });
+        }
+        setUsuarios(list);
+      } catch (e) {
+        console.error("Erro ao buscar usuários", e);
+      }
+    };
+
+    fetchUsers();
+  }, []);
+
+  return (
+    <div className={style.container}>
+      <CabecalhoVerde>
+        <span className={style.title}>Gerenciamento</span>
+      </CabecalhoVerde>
+      <div className={style.menu}>
+        <button
+          className={style.linkButton}
+          onClick={() => navigate("/register")}
+        >
+          Criar Usuário
+        </button>
+      </div>
+      <table className={style.table}>
+        <thead>
+          <tr>
+            <th>Nome</th>
+            <th>E-mail</th>
+            <th>Status</th>
+            <th>Nível de Acesso</th>
+            <th>Status de Pagamento</th>
+          </tr>
+        </thead>
+        <tbody>
+          {usuarios.map((u, idx) => (
+            <tr key={idx}>
+              <td>{u.nome}</td>
+              <td>{u.email}</td>
+              <td>{u.statusUsuario ? "Ativo" : "Inativo"}</td>
+              <td>{u.nivel}</td>
+              <td>
+                {typeof u.statusPagamento === "boolean"
+                  ? u.statusPagamento
+                    ? "Pago"
+                    : "Pendente"
+                  : u.statusPagamento}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/screens/Gerenciamento/style.module.css
+++ b/src/screens/Gerenciamento/style.module.css
@@ -1,0 +1,40 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 8vh;
+  min-height: 100vh;
+  background-color: #f2f2f2;
+}
+
+.title {
+  color: white;
+  font-size: 1.8rem;
+}
+
+.menu {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.linkButton {
+  padding: 0.6rem 1rem;
+  background-color: #0a9154;
+  color: white;
+  border: none;
+  border-radius: 0.4rem;
+  cursor: pointer;
+}
+
+.table {
+  width: 90%;
+  max-width: 800px;
+  border-collapse: collapse;
+  background-color: #ffffffd8;
+}
+.table th,
+.table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- add Gerenciamento screen to manage users
- list usuarios with their access level information
- include a button to create user from Gerenciamento page
- replace header register link with Gerenciamento link
- register new route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847bd8e6f588329a861e74e697c7984