### PR TITLE
Update home background and card buttons

### DIFF
--- a/src/componentes/CardButton/index.tsx
+++ b/src/componentes/CardButton/index.tsx
@@ -1,4 +1,9 @@
-import styles from "./style.module.css"
+import styles from "./style.module.css";
+import { useState } from "react";
+import defaultImg from "../../assets/3.png";
+import hover1 from "../../assets/4.png";
+import hover2 from "../../assets/5.png";
+import hover3 from "../../assets/6.png";
 
 type Props = {
 	classe: string;
@@ -6,10 +11,33 @@ type Props = {
   action:()=>void
 };
 
-export const CardButton = ({ classe, text ,action}:Props) => {
- return (
-   <button className={`${styles[classe]} ${styles.btn}`} onClick={()=>action()}>
-     <span className={styles.btnText}>{text}</span>
-   </button>
- );
+export const CardButton = ({ classe, text, action }: Props) => {
+  const [src, setSrc] = useState(defaultImg);
+
+  const hoverMap: Record<string, string> = {
+    btn_1: hover1,
+    btn_2: hover2,
+    btn_3: hover3,
+  };
+
+  const handleMouseEnter = () => {
+    const hoverImg = hoverMap[classe];
+    if (hoverImg) setSrc(hoverImg);
+  };
+
+  const handleMouseLeave = () => {
+    setSrc(defaultImg);
+  };
+
+  return (
+    <button
+      className={`${styles.btn}`}
+      onClick={() => action()}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <img src={src} className={styles.btnImage} alt="" />
+      <span className={styles.btnText}>{text}</span>
+    </button>
+  );
 };

--- a/src/componentes/CardButton/style.module.css
+++ b/src/componentes/CardButton/style.module.css
@@ -2,13 +2,10 @@
  position: relative;
  height: 70%;
  aspect-ratio: 0.6;
- background-image: url('../../assets/3.png');
- background-size: cover;
- background-position: center;
- background-repeat: no-repeat;
  border: none;
  background-color: transparent;
  cursor: pointer;
+ overflow: hidden;
  display: flex;
  justify-content: center;
  align-items: center;
@@ -18,21 +15,12 @@
  margin-bottom: -10%;
 }
 
-.btn img { 
- width: 200px;
- background-color: transparent;
+.btnImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
-.btn_1:hover {
- background-image: url('../../assets/4.png');
-}
-
-.btn_2:hover {
- background-image: url('../../assets/5.png');
-}
-.btn_3:hover {
- background-image: url('../../assets/6.png');
-}
 .btnText {
  position: absolute;
  top: -2rem;

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { RootState } from "../../store";
 import { useSelector } from "react-redux";
 import { useState } from "react";
+import backgroundImg from "../../assets/pk5.png";
 
 export function Home() {
   const navigate = useNavigate();
@@ -29,6 +30,7 @@ export function Home() {
   return (
     <>
       <div className={styles.background}>
+        <img src={backgroundImg} className={styles.backgroundImage} alt="" />
         <CabecalhoVerde>
           {userData && <span style={{color:'#ffff', fontSize:'2rem'}}>{userData.nome}</span>}
         </CabecalhoVerde>

--- a/src/screens/Home/style.module.css
+++ b/src/screens/Home/style.module.css
@@ -18,10 +18,7 @@ body {
 }
 
 .background {
-  background-image: url("../../assets/pk5.png"); /* Imagem de fundo */
-  background-size:cover;
-  background-repeat: no-repeat;
-  background-position: top; /* <- Alinha pelo topo */
+  position: relative;
   width: 100vw;
   height: 100vh;
   display: flex;
@@ -91,4 +88,13 @@ body {
   100% {
     left: 125%;
   }
+}
+.backgroundImage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -1;
 }


### PR DESCRIPTION
## Summary
- remove background images from Home styles and display a fullscreen background `<img>` instead
- convert CardButton to use `<img>` elements and hover logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6847c81ffd4883299476f7076ad29047