### PR TITLE
Fix back link on user registration page

### DIFF
--- a/src/screens/Register/index.tsx
+++ b/src/screens/Register/index.tsx
@@ -200,7 +200,7 @@ export function Register() {
           />
         </div>
         <div style={{ display: "flex", justifyContent: "space-between" ,width:"80%"}}>
-          <button className={style.voltarloginButton} onClick={() => navigate("/home")}>Voltar</button>
+          <button className={style.voltarloginButton} onClick={() => navigate("/gerenciamento")}>Voltar</button>
           <button className={style.loginButton} type="submit">Cadastrar</button>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- update the "Voltar" button on the Register screen to link back to the management page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848ca0905d88329942f009ae6fe9a3e