### PR TITLE
Add payment management controls

### DIFF
--- a/src/componentes/Modal/index.tsx
+++ b/src/componentes/Modal/index.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import styles from './style.module.css';
+
+export function Modal({ children }: { children: React.ReactNode }) {
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.content}>{children}</div>
+    </div>
+  );
+}
+
+interface ConfirmProps {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmModal({ message, onConfirm, onCancel }: ConfirmProps) {
+  return (
+    <Modal>
+      <p>{message}</p>
+      <div className={styles.buttons}>
+        <button onClick={onConfirm}>Sim</button>
+        <button onClick={onCancel}>Cancelar</button>
+      </div>
+    </Modal>
+  );
+}
+
+interface DateModalProps {
+  onSave: (date: string) => void;
+  onCancel: () => void;
+}
+
+export function DateModal({ onSave, onCancel }: DateModalProps) {
+  const [date, setDate] = useState('');
+  return (
+    <Modal>
+      <p>Selecione a data do pagamento</p>
+      <input type="date" value={date} onChange={e => setDate(e.target.value)} />
+      <div className={styles.buttons}>
+        <button onClick={() => onSave(date)}>Salvar</button>
+        <button onClick={onCancel}>Cancelar</button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/componentes/Modal/style.module.css
+++ b/src/componentes/Modal/style.module.css
@@ -1,0 +1,26 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.content {
+  background: white;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  text-align: center;
+}
+
+.buttons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1rem;
+}

--- a/src/screens/Gerenciamento/index.tsx
+++ b/src/screens/Gerenciamento/index.tsx
@@ -1,20 +1,34 @@
 import { useEffect, useState } from "react";
-import { collection, getDocs, query, where } from "firebase/firestore";
+import { collection, getDocs, query, where, updateDoc, doc } from "firebase/firestore";
 import CabecalhoVerde from "../../componentes/CabecalhoVerde";
 import { db } from "../../Server/firebase";
 import style from "./style.module.css";
 import { useNavigate } from "react-router-dom";
+import { ConfirmModal, DateModal } from "../../componentes/Modal";
 
 interface UserInfo {
+  id: string;
+  acessoId: string;
   nome: string;
   email: string;
   statusUsuario: boolean;
   nivel: string;
   statusPagamento: boolean | string;
+  data_ultimo_pagamento?: string | null;
+  status_ultimo_pagamento?: boolean;
 }
 
 export default function Gerenciamento() {
   const [usuarios, setUsuarios] = useState<UserInfo[]>([]);
+  const [confirm, setConfirm] = useState<{
+    message: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+  } | null>(null);
+  const [dateModal, setDateModal] = useState<{
+    onSave: (date: string) => void;
+    onCancel: () => void;
+  } | null>(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -26,6 +40,7 @@ export default function Gerenciamento() {
           const dataUser = docUser.data();
           let nivel = "";
           let statusPagamento: boolean | string = "N/A";
+          let acessoId = "";
           const acessoQuery = query(
             collection(db, "acesso"),
             where("id", "==", dataUser.id)
@@ -33,15 +48,20 @@ export default function Gerenciamento() {
           const acessoSnapshot = await getDocs(acessoQuery);
           if (!acessoSnapshot.empty) {
             const acessoData = acessoSnapshot.docs[0].data();
+            acessoId = acessoSnapshot.docs[0].id;
             nivel = String(acessoData.nivel);
             statusPagamento = acessoData.status;
           }
           list.push({
+            id: docUser.id,
+            acessoId,
             nome: dataUser.nome,
             email: dataUser.email,
             statusUsuario: dataUser.status,
             nivel,
             statusPagamento,
+            data_ultimo_pagamento: dataUser.data_ultimo_pagamento || null,
+            status_ultimo_pagamento: dataUser.status_ultimo_pagamento || false,
           });
         }
         setUsuarios(list);
@@ -52,6 +72,108 @@ export default function Gerenciamento() {
 
     fetchUsers();
   }, []);
+
+  const toggleStatusUsuario = (index: number) => {
+    const usuario = usuarios[index];
+    const novoStatus = !usuario.statusUsuario;
+    setConfirm({
+      message: "Tem certeza desta ação?",
+      onConfirm: async () => {
+        await updateDoc(doc(db, "usuario", usuario.id), { status: novoStatus });
+        const updated = { ...usuario, statusUsuario: novoStatus };
+        setUsuarios((prev) => prev.map((u, i) => (i === index ? updated : u)));
+        setConfirm(null);
+      },
+      onCancel: () => {
+        setConfirm(null);
+      },
+    });
+  };
+
+  const toggleStatusPagamento = (index: number) => {
+    const usuario = usuarios[index];
+    const novoStatus = !(usuario.statusPagamento === true);
+    setConfirm({
+      message: "Tem certeza desta ação?",
+      onConfirm: () => handleConfirmPagamento(usuario, index, novoStatus),
+      onCancel: () => setConfirm(null),
+    });
+  };
+
+  const handleConfirmPagamento = (
+    usuario: UserInfo,
+    index: number,
+    novoStatus: boolean
+  ) => {
+    if (novoStatus) {
+      setConfirm({
+        message: "Pagamento realizado hoje?",
+        onConfirm: async () => {
+          const today = new Date().toISOString().split("T")[0];
+          await Promise.all([
+            updateDoc(doc(db, "acesso", usuario.acessoId), { status: true }),
+            updateDoc(doc(db, "usuario", usuario.id), {
+              data_ultimo_pagamento: today,
+              status_ultimo_pagamento: true,
+            }),
+          ]);
+          const updated = {
+            ...usuario,
+            statusPagamento: true,
+            data_ultimo_pagamento: today,
+            status_ultimo_pagamento: true,
+          };
+          setUsuarios((prev) => prev.map((u, i) => (i === index ? updated : u)));
+          setConfirm(null);
+        },
+        onCancel: () => {
+          setConfirm(null);
+          setDateModal({
+            onSave: async (date) => {
+              await Promise.all([
+                updateDoc(doc(db, "acesso", usuario.acessoId), { status: true }),
+                updateDoc(doc(db, "usuario", usuario.id), {
+                  data_ultimo_pagamento: date,
+                  status_ultimo_pagamento: true,
+                }),
+              ]);
+              const updated = {
+                ...usuario,
+                statusPagamento: true,
+                data_ultimo_pagamento: date,
+                status_ultimo_pagamento: true,
+              };
+              setUsuarios((prev) =>
+                prev.map((u, i) => (i === index ? updated : u))
+              );
+              setDateModal(null);
+            },
+            onCancel: () => setDateModal(null),
+          });
+        },
+      });
+    } else {
+      setConfirm({
+        message: "Tem certeza desta ação?",
+        onConfirm: async () => {
+          await Promise.all([
+            updateDoc(doc(db, "acesso", usuario.acessoId), { status: false }),
+            updateDoc(doc(db, "usuario", usuario.id), {
+              status_ultimo_pagamento: false,
+            }),
+          ]);
+          const updated = {
+            ...usuario,
+            statusPagamento: false,
+            status_ultimo_pagamento: false,
+          };
+          setUsuarios((prev) => prev.map((u, i) => (i === index ? updated : u)));
+          setConfirm(null);
+        },
+        onCancel: () => setConfirm(null),
+      });
+    }
+  };
 
   return (
     <div className={style.container}>
@@ -81,19 +203,35 @@ export default function Gerenciamento() {
             <tr key={idx}>
               <td>{u.nome}</td>
               <td>{u.email}</td>
-              <td>{u.statusUsuario ? "Ativo" : "Inativo"}</td>
+              <td>
+                <input
+                  type="checkbox"
+                  checked={u.statusUsuario}
+                  onChange={() => toggleStatusUsuario(idx)}
+                />
+              </td>
               <td>{u.nivel}</td>
               <td>
-                {typeof u.statusPagamento === "boolean"
-                  ? u.statusPagamento
-                    ? "Pago"
-                    : "Pendente"
-                  : u.statusPagamento}
+                <input
+                  type="checkbox"
+                  checked={u.statusPagamento === true}
+                  onChange={() => toggleStatusPagamento(idx)}
+                />
               </td>
             </tr>
           ))}
         </tbody>
       </table>
+      {confirm && (
+        <ConfirmModal
+          message={confirm.message}
+          onConfirm={confirm.onConfirm}
+          onCancel={confirm.onCancel}
+        />
+      )}
+      {dateModal && (
+        <DateModal onSave={dateModal.onSave} onCancel={dateModal.onCancel} />
+      )}
     </div>
   );
 }

--- a/src/screens/Register/index.tsx
+++ b/src/screens/Register/index.tsx
@@ -76,6 +76,8 @@ export function Register() {
         status: true,
         currentSession: "",
         dinamico: true,
+        data_ultimo_pagamento: null,
+        status_ultimo_pagamento: false,
         dataCadastro: serverTimestamp()
       };
 

--- a/src/slices/index.tsx
+++ b/src/slices/index.tsx
@@ -6,6 +6,8 @@ export interface UserData {
   id: string;
   nome: string;
   dinamico: boolean;
+  data_ultimo_pagamento?: string | null;
+  status_ultimo_pagamento?: boolean;
   currentSession?: string | null;
 }
 

--- a/src/utils/ParseUserData.tsx
+++ b/src/utils/ParseUserData.tsx
@@ -19,7 +19,9 @@ export function ParseUserData(data: DocumentData): UserData {
     status: data.status,
     id: data.id,
     nome: data.nome,
-    dinamico:data.dinamico,
-    currentSession:data.currentSession||null,
+    dinamico: data.dinamico,
+    data_ultimo_pagamento: data.data_ultimo_pagamento || null,
+    status_ultimo_pagamento: data.status_ultimo_pagamento || false,
+    currentSession: data.currentSession || null,
   };
 }


### PR DESCRIPTION
## Summary
- add reusable Modal components
- track last payment in user slices and parse helpers
- store payment fields when registering a user
- enable admins to toggle status and payment with confirmations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848ced1d8588329ba61f1462367711a