### PR TITLE
Add payment info fields to user registration

### DIFF
--- a/src/screens/Register/index.tsx
+++ b/src/screens/Register/index.tsx
@@ -18,7 +18,8 @@ export function Register() {
     confirmarSenha: "",
     nome: "",
     nivel: "",
-    observacao: ""
+    observacao: "",
+    data_ultimo_pagamento: ""
   });
 
   const [showPassword, setShowPassword] = useState(false);
@@ -29,9 +30,9 @@ export function Register() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const { email, senha, confirmarSenha, nome, nivel, observacao } = formData;
+    const { email, senha, confirmarSenha, nome, nivel, observacao, data_ultimo_pagamento } = formData;
 
-    if (!email || !senha || !confirmarSenha || !nome || !nivel) {
+    if (!email || !senha || !confirmarSenha || !nome || !nivel || !data_ultimo_pagamento) {
       toast.warning("Preencha todos os campos obrigatórios.");
       return;
     }
@@ -83,6 +84,8 @@ export function Register() {
         id: uid,
         nivel,
         status: true,
+        status_ultimo_pagamento: true,
+        data_ultimo_pagamento,
         observacao,
         dataCadastro: serverTimestamp(),
         dataInicio: serverTimestamp(),
@@ -99,7 +102,8 @@ export function Register() {
         confirmarSenha: "",
         nome: "",
         nivel: "",
-        observacao: ""
+        observacao: "",
+        data_ultimo_pagamento: ""
       });
     } catch (error) {
       console.error("Erro ao cadastrar:", error);
@@ -197,6 +201,14 @@ export function Register() {
             placeholder="Observação"
             value={formData.observacao}
             setValue={(val: string) => handleChange("observacao", val)}
+          />
+        </div>
+        <div className={style.inputGroup}>
+          <InputText
+            type="date"
+            placeholder="Data de pagamento"
+            value={formData.data_ultimo_pagamento}
+            setValue={(val: string) => handleChange("data_ultimo_pagamento", val)}
           />
         </div>
         <div style={{ display: "flex", justifyContent: "space-between" ,width:"80%"}}>


### PR DESCRIPTION
## Summary
- add `data_ultimo_pagamento` value in form state
- require the new date field on submit
- persist `status_ultimo_pagamento` (true) and `data_ultimo_pagamento` in acesso document
- reset and display new input on register page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations and modules)*

------
https://chatgpt.com/codex/tasks/task_e_6848cf6ca7448329975a56efddcd62ae