### PR TITLE
Add cookie consent and DB update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { RoutesApp } from './Routes';
 import { useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from './hooks';
+import CookieConsent from './componentes/CookieConsent';
 import { auth, db } from "./Server/firebase";
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { collection, query, where, getDocs, doc, getDoc
@@ -17,6 +18,9 @@ function App() {
   const dispatch = useAppDispatch();
   const [internalLoading, setInternalLoading] = useState(true);
   const { loading: authLoading, authChecked } = useAppSelector(state => state.auth);
+  const [showCookie, setShowCookie] = useState(() => {
+    return localStorage.getItem('cookieConsent') !== 'true';
+  });
 
   useEffect(() => {
     console.log("App carregado. Estado inicial:", authLoading);
@@ -136,7 +140,19 @@ function App() {
     return <Loading />;
   }
 
-  return <RoutesApp />;
+  return (
+    <>
+      {showCookie && (
+        <CookieConsent
+          onAccept={() => {
+            localStorage.setItem('cookieConsent', 'true');
+            setShowCookie(false);
+          }}
+        />
+      )}
+      <RoutesApp />
+    </>
+  );
 }
 
 export default App;

--- a/src/Server/updateCookieConsent.tsx
+++ b/src/Server/updateCookieConsent.tsx
@@ -1,0 +1,12 @@
+import { collection, query, where, getDocs, setDoc } from 'firebase/firestore';
+import { db } from './firebase';
+
+export async function updateCookieConsent(id: string, consent: boolean) {
+  const q = query(collection(db, 'usuario'), where('id', '==', id));
+  const snapshot = await getDocs(q);
+  if (snapshot.empty) {
+    throw new Error(`Nenhum usuário encontrado com o id: ${id}`);
+  }
+  const docRef = snapshot.docs[0].ref;
+  await setDoc(docRef, { cookieConsent: consent }, { merge: true });
+}

--- a/src/componentes/CookieConsent/index.tsx
+++ b/src/componentes/CookieConsent/index.tsx
@@ -1,0 +1,32 @@
+import { useAppSelector } from '../../hooks';
+import { updateCookieConsent } from '../../Server/updateCookieConsent';
+import styles from './style.module.css';
+
+interface Props {
+  onAccept: () => void;
+}
+
+export default function CookieConsent({ onAccept }: Props) {
+  const userData = useAppSelector(state => state.user.userData);
+
+  const handleAccept = async () => {
+    if (userData) {
+      try {
+        await updateCookieConsent(userData.id, true);
+      } catch (err) {
+        console.error('Erro ao salvar consentimento:', err);
+      }
+    }
+    onAccept();
+  };
+
+  return (
+    <div className={styles.banner}>
+      <p>
+        Este site utiliza cookies para aprimorar sua experiência. Ao continuar
+        navegando, você concorda com nossa política de privacidade.
+      </p>
+      <button onClick={handleAccept}>Aceitar</button>
+    </div>
+  );
+}

--- a/src/componentes/CookieConsent/style.module.css
+++ b/src/componentes/CookieConsent/style.module.css
@@ -1,0 +1,25 @@
+.banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.85);
+  color: var(--white);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  z-index: var(--z-toast);
+  box-sizing: border-box;
+}
+
+.banner button {
+  margin-top: 0.5rem;
+  padding: 0.5rem 1rem;
+  background-color: var(--primary-green);
+  border: none;
+  color: var(--white);
+  cursor: pointer;
+  border-radius: 4px;
+  font-weight: bold;
+}

--- a/src/screens/Register/index.tsx
+++ b/src/screens/Register/index.tsx
@@ -75,6 +75,7 @@ export function Register() {
         nome,
         email,
         status: true,
+        cookieConsent: false,
         currentSession: "",
         dinamico: true,
         data_ultimo_pagamento: null,

--- a/src/slices/index.tsx
+++ b/src/slices/index.tsx
@@ -6,6 +6,7 @@ export interface UserData {
   id: string;
   nome: string;
   dinamico: boolean;
+  cookieConsent?: boolean;
   data_ultimo_pagamento?: string | null;
   status_ultimo_pagamento?: boolean;
   currentSession?: string | null;

--- a/src/utils/ParseUserData.tsx
+++ b/src/utils/ParseUserData.tsx
@@ -23,5 +23,6 @@ export function ParseUserData(data: DocumentData): UserData {
     data_ultimo_pagamento: data.data_ultimo_pagamento || null,
     status_ultimo_pagamento: data.status_ultimo_pagamento || false,
     currentSession: data.currentSession || null,
+    cookieConsent: data.cookieConsent || false,
   };
 }


### PR DESCRIPTION
## Summary
- implement a CookieConsent banner component
- add server util to store cookie consent
- extend user model and parser with cookieConsent flag
- record default consent on registration
- show consent banner in `App`

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6849087376208329ac9ac63274940702